### PR TITLE
Add Skill Documentation

### DIFF
--- a/docs/developers/skill_json.md
+++ b/docs/developers/skill_json.md
@@ -1,0 +1,100 @@
+# `skill.json` spec
+This document specifies valid `skill.json` metadata.
+
+### `title`
+String skill title to be used in store listings and other user-facing places. This
+is not guaranteed to be unique, so multiple skills may have the same `title`.
+
+### `url`
+String URL that a skill is hosted at (usually on github.com)
+
+### `short_description`
+String short description or by-line for a skill. This may be used in store listings
+or other user-facing places.
+
+### `description`
+String description for a skill. This may be used in a 'details' page or similar.
+
+### `examples`
+List of string utterances that are handled by this skill. These should be formatted
+as sentences, ready to be displayed as-is and should not include any wake words
+or other extraneous information.
+
+### `desktopFile` (optional)
+Relative path to a `.desktop` file that can be used to launch a persistent skill
+GUI.
+
+### `systemDeps`
+Boolean indicating if a skill includes system package dependencies.
+
+### `requirements`
+Dictionary with keys `python`, `system`, and `skill`, each with values indicating
+requirements.
+
+#### python
+List of valid package specs, as would be found in `requirements.txt`.
+
+#### system
+Dictionary of package manager (i.e. `apt`) to a list of required packages.
+
+#### skill
+List of required skills, identified by skill_id.
+
+### `incompatible_skills`
+List of skills that can not be loaded at the same time as this one.
+
+### `platforms`
+List of string platforms this skill is compatible with.
+
+Valid options: `['i386', 'x86_64', 'ia64', 'arm64', 'arm']`
+
+### `license`
+String licence identifier this skill is provided under.
+
+### `icon`
+String URI for an icon to use in user-facing UIs.
+
+### `category`
+Primary category this skill belongs to.
+
+Valid options: `["Daily", "Configuration", "Entertainment", "Information", "IoT",
+"Music & Audio", "Media", "Productivity", "Transport"]`
+
+### `categories`
+List of categories this skill belongs to.
+
+Valid options: `["Daily", "Configuration", "Entertainment", "Information", "IoT",
+"Music & Audio", "Media", "Productivity", "Transport"]`
+
+### `tags`
+List of string tags to apply to this skill. Tags can be any string and help with
+searchability; some skill listings might require a skill contain a particular tag.
+
+### `skillname`
+String name of the skill, usually the Git repository name.
+
+### `authorname`
+String name of the skill's author, usually the Git user/organization name.
+
+### `foldername`
+Optional string base directory to install the skill to; default `null`.
+
+### `lang`
+String BCP-47 language code (i.e. `en-us`) the skill.json and README.md files are written in.
+
+### `lang_support`
+Dict of other supported languages (BCP-47 language codes) to dict with keys:
+`skillname`, `description`, and `examples`. Missing fields will default to top-level fields.
+
+### `credits` (optional)
+List of string credits for a skill, usually GitHub usernames. 
+
+### `branch` (optional)
+Git branch this `skill.json` spec is associated with.
+
+### `warning` (optional)
+Optional string warning to display when installing a skill.
+
+### `summary` (optional)
+String short description or by-line for a skill. This may be used in store listings
+or other user-facing places.

--- a/docs/skill_development/adapt_intents.md
+++ b/docs/skill_development/adapt_intents.md
@@ -1,0 +1,79 @@
+# Adapt Intents
+Adapt is an intent parser, developed by Mycroft AI. 
+There is [official documentation](https://mycroft-ai.gitbook.io/docs/mycroft-technologies/adapt)
+published by Mycroft, but this document addresses Adapt in the context of
+creating a skill for Neon/OVOS/Mycroft "Classic".
+
+## Intent Example
+Adapt intents use a collection of vocabulary files to build an intent. Vocabularies
+are specified in `.voc` files. The Alerts skill uses an Adapt intent
+[to create an alarm](https://github.com/NeonGeckoCom/skill-alerts/blob/dev/__init__.py#L203-L208).
+
+### Vocabulary Files
+Using the alarm example, the `alarm.voc` file looks like: 
+```
+alarm
+alarms
+wake me up
+```
+
+Each line contains a word or phrase with the meaning "alarm". 
+
+## Regex Files
+Using the [CaffeineWiz skill as an example](https://github.com/NeonGeckoCom/skill-caffeinewiz/blob/932ea389313066ca5a0a8325eb233495d4dbb450/__init__.py#L161-L162),
+a `.rx` file is used to specify a regular expression to extract a `drink` entity.
+
+The intent_handler looks like:
+```python
+@intent_handler(IntentBuilder("CaffeineContentIntent")
+                .require("query_caffeine").require("drink"))
+```
+
+And `drink.rx` looks like:
+```
+(of|in) (?P<drink>.*)
+```
+
+`drink` in the `intent_handler` refers to the regex group (not the filename) in
+this case. If the user said "how much caffeine is in coca cola", the regex would
+match `coca cola` as `drink` and in the message passed to the intent handler,
+`message.data['drink'] == 'coca cola`.
+
+## Registering an Intent
+In the alarm example, our intent is registered with the `intent_handler` decorator:
+```python
+from adapt.intent import IntentBuilder
+from mycroft.skills import intent_handler
+
+    @intent_handler(IntentBuilder("CreateAlarm").require("set")
+                    .require("alarm").optionally("playable")
+                    .optionally("weekdays").optionally("weekends")
+                    .optionally("everyday").optionally("repeat")
+                    .optionally("until").optionally("script")
+                    .optionally("priority"))
+    def handle_create_alarm(self, message: Message):
+        """
+        Intent handler for creating an alarm
+        :param message: Message associated with request
+        """
+        pass
+```
+This creates an intent named "CreateAlarm" and specifies several vocabulary files
+that are either required for the intent to match, or optionally present in the
+utterance. Matched vocabulary is added to Message data, so `message.data['alarm']`
+will contain "alarm", "alarms", or "wake me up" based on our vocabulary file.
+If the user said "set an alarm for weekends at 9 AM", `message.data['weekends']` would
+contain "weekends".
+
+### IntentBuilder methods
+There are three methods to register vocabulary to an Adapt Intent. Any vocabulary
+that is found in a user utterance will be added to `message.data`.
+
+#### require
+This specifies that an utterance must contain this vocabulary to be considered a match.
+
+#### optionally
+This specifies that an utterance might contain this vocabulary.
+
+#### one_of
+This specifies that an utterance must contain at least one of the passed vocabularies.

--- a/docs/skill_development/padatious_intents.md
+++ b/docs/skill_development/padatious_intents.md
@@ -4,7 +4,7 @@ There is [official documentation](https://mycroft-ai.gitbook.io/docs/mycroft-tec
 published by Mycroft, but this document addresses Padatious in the context of
 creating a skill for Neon/OVOS/Mycroft "Classic".
 
-## Intent Files
+## Intents
 Unlike Adapt intents, Padatious intents are specified as a list of potential user
 utterances. These examples are specified in an `.intent` file. For example, the
 Update Skill uses a Padatious intent [update_device.intent](https://github.com/NeonGeckoCom/skill-update/blob/ae8ac710bb133aa2b9805319e3d513bfb934e6c7/locale/en-us/intent/update_device.intent).
@@ -55,7 +55,7 @@ From our skill example:
 :0 update my device
 ```
 
-### Entities
+## Entities
 It might be useful to extract a word or phrase from an utterance. Below is an
 example from the [stock skill](https://github.com/NeonGeckoCom/skill-stock/blob/4f4b7c526994060c88c5e5031d8d4a6245f61acc/locale/en-us/intent/stock_price.intent):
 
@@ -69,7 +69,7 @@ In the above intent file, `company` is an entity, so the utterance "what is micr
 would match the intent and include: `{"company": "microsoft"}` in the `Message` data.
 > Note that entity names should always be specified as lowercase alpha characters.
 
-#### .entity files
+### .entity files
 If you wanted to limit valid values for `company` in the above example, you could
 create a `company.entity` file that looks like:
 ```
@@ -83,16 +83,28 @@ apple
 This would limit `company` to only values in the `company.entity` file, so the
 utterance "what is tesla trading at" would NOT match in this case.
 
+## Registering an Intent
+Once you have specified an `.intent` file, you can register an intent handler
+method in the skill.
+
+Using the [update skill example](https://github.com/NeonGeckoCom/skill-update/blob/ae8ac710bb133aa2b9805319e3d513bfb934e6c7/__init__.py#L130):
+```python
+from mycroft.skills import intent_file_handler
+class UpdateSkill:
+    @intent_file_handler("update_device.intent")
+    def handle_update_device(self, message):
+        """
+        Handle a user request to check for updates.
+        :param message: message object associated with request
+        """
+        pass
+```
+
+Note that the intent file basename, including the file extension, is passed to the decorator.
+
 ## Advantages over Adapt
 The above intents could just as easily be added to a `.voc` file and then a user
 request "update my device" would behave exactly the same. One of the advantages
 of Padatious is that an intent is trained on examples, so where Adapt would match
 "are there any updates in my inbox" because it contains "are there any updates",
 Padatious is less likely to match that utterance.
-
-
-
-``````
-do you have any updates
-run updates
-```

--- a/docs/skill_development/padatious_intents.md
+++ b/docs/skill_development/padatious_intents.md
@@ -1,0 +1,98 @@
+# Padadious Intents
+Padatious is an intent parser, developed by Mycroft AI. 
+There is [official documentation](https://mycroft-ai.gitbook.io/docs/mycroft-technologies/padatious)
+published by Mycroft, but this document addresses Padatious in the context of
+creating a skill for Neon/OVOS/Mycroft "Classic".
+
+## Intent Files
+Unlike Adapt intents, Padatious intents are specified as a list of potential user
+utterances. These examples are specified in an `.intent` file. For example, the
+Update Skill uses a Padatious intent [update_device.intent](https://github.com/NeonGeckoCom/skill-update/blob/ae8ac710bb133aa2b9805319e3d513bfb934e6c7/locale/en-us/intent/update_device.intent).
+
+### Simple Intents
+Below are some simple intents in our Update Skill example:
+```
+update my device
+check for updates
+are there any updates
+i want you to update
+```
+
+Each line specifies something a user might say if their `intent` is to update
+their device.
+
+### Parentheses Expansion
+Padatious intents can be specified with parenthetical values that are expanded.
+
+From our Update Skill example:
+```
+update my( core| skills|)( software|)
+```
+
+The above line could be expanded to:
+```
+update my core software
+update my core
+update my skills software
+update my skills
+update my software
+update my
+```
+
+Note that spaces are treated like any other character, so it's important to pay
+attention to parentheses that contain a `None` option and where that might create
+a missing or additional space.
+
+### Extra Unknown Words
+Sometimes you might want to account for an extra filler word in an intent. For
+example, a user might say "um, check for updates" or "you update my device"; if
+they used a button instead of a wake word to wake the device, they might say
+"neon, check for updates. These unknown words can be accounted for with `:0` 
+which specifies one word.
+
+From our skill example:
+```
+:0 update my device
+```
+
+### Entities
+It might be useful to extract a word or phrase from an utterance. Below is an
+example from the [stock skill](https://github.com/NeonGeckoCom/skill-stock/blob/4f4b7c526994060c88c5e5031d8d4a6245f61acc/locale/en-us/intent/stock_price.intent):
+
+```
+(what is|tell me|i want to know) (the |) (share|stock|trade|trading) (price|value) for {company}
+(tell me|i want to know) what {company} is trading at
+what is {company} (trading at|stock price|share price)
+```
+
+In the above intent file, `company` is an entity, so the utterance "what is microsoft trading at"
+would match the intent and include: `{"company": "microsoft"}` in the `Message` data.
+> Note that entity names should always be specified as lowercase alpha characters.
+
+#### .entity files
+If you wanted to limit valid values for `company` in the above example, you could
+create a `company.entity` file that looks like:
+```
+microsoft
+amazon
+netflix
+google
+apple
+```
+
+This would limit `company` to only values in the `company.entity` file, so the
+utterance "what is tesla trading at" would NOT match in this case.
+
+## Advantages over Adapt
+The above intents could just as easily be added to a `.voc` file and then a user
+request "update my device" would behave exactly the same. One of the advantages
+of Padatious is that an intent is trained on examples, so where Adapt would match
+"are there any updates in my inbox" because it contains "are there any updates",
+Padatious is less likely to match that utterance.
+
+
+
+``````
+do you have any updates
+run updates
+```

--- a/docs/skill_development/skill_documentation.md
+++ b/docs/skill_development/skill_documentation.md
@@ -1,0 +1,157 @@
+# Skill Documentation
+Some basic documentation about a skill helps user discovery and is necessary for
+a skill to be included in some lists/stores.
+
+## skill.json
+The [`skill.json`](https://neongeckocom.github.io/neon-docs/developers/skill_json/) 
+file contains parsed information about a skill, such as examples,
+a description, known incompatible skills, and dependent skills. The link above
+contains details about the `skill.json` spec, but this document will discuss the
+existing tools and automations to generate that `json` file for a skill.
+
+### Automating `skill.json` Updates
+The following automation can be added to a skill repository as 
+`.github/workflows/update_skill_json.yml` to enable automated updates to `skill.json`
+when committing a change to GitHub:
+
+```yaml
+name: Update skill.json
+on:
+  push:
+
+jobs:
+  update_skill_json:
+    uses: neongeckocom/.github/.github/workflows/skill_update_json_spec.yml@master
+```
+
+The above automation assumes `README.md`, `LICENSE.md`, and either 
+`requirements.txt` or `manifest.yml` are present in the skill repository.
+
+## README.md
+All skills should contain a `README.md` file which is shown by default when viewing
+the skill repository on GitHub. Using [skill-alerts](https://github.com/NeonGeckoCom/skill-alerts/blob/1.4.0/README.md?plain=1)
+as an example, this document will go through some of the expected `README.md` sections.
+
+The first line of the file specifies a skill icon (in this case, a file in the
+git repository `logo.svg`) and a title for the skill (`Alerts`)
+```markdown
+# <img src='./logo.svg' card_color="#FF8600" width="50" style="vertical-align:bottom" style="vertical-align:bottom">Alerts
+```
+---
+The `Summary` section contains a brief description of the skill.
+```markdown
+## Summary  
+  
+A skill to schedule alarms, timers, and reminders
+```
+---
+The `Description` contains a much longer description of the skill, including some
+information about how the skill works.
+```markdown
+## Description  
+  
+The skill provides functionality to create alarms, timers and reminders, remove them by name, time, or type, and ask for
+what is active. You may also silence all alerts and ask for a summary of what was missed if you were away, your device
+was off, or you had quiet hours enabled.
+
+Alarms and reminders may be set to recur daily or weekly. An active alert may be snoozed for a specified amount of time
+while it is active. Any alerts that are not acknowledged will be added to a list of missed alerts that may be read and
+cleared when requested.
+```
+---
+The `Examples` section contains some example utterances and in this case, some
+descriptions about what the examples do. Each example is formatted as a sentence
+that is ready to be shown to the user as-is; the `"` are optional. Note that the
+text that is not part of an unordered list (no leading `-` or `*`) is excluded 
+from the parsed list of examples.
+```markdown
+## Examples  
+  
+If you are skipping wake words, say `Neon` followed by any of the following, otherwise say your `Wake Word`:
+
+- "Set an alarm for 8 AM."
+- "When is my next alarm?"
+- "Cancel my 8 AM alarm."
+
+- "Set a 5 minute timer."
+- "How much time is left?"
+
+- "Remind me to go home at 6."
+- "Remind me to take out the trash every thursday at 7 PM."
+- "What are my reminders?"
+
+- "Cancel all alarms."
+- "Cancel all timers."
+- "Cancel all reminders."
+
+- "Go to sleep."
+- "Start quiet hours."
+
+If there is an active alert (expired and currently speaking or playing), you may snooze or dismiss it:
+
+- "Stop."
+
+- "Snooze."
+- "Snooze for 1 minute."
+  
+If you had quiet hours enabled, your device was off, or you were away and missed an alert, you may ask for a summary:
+
+- "Wake up."
+- "What did I miss?"
+- "Did I miss anything?"
+```
+---
+`Incompatible Skills`, like `Examples` contains a list of skills that conflict with
+the `skill-alerts.neongeckocom` skill. This example uses skill ID's with links to
+the skill URLs, but only the URLs are required
+```markdown
+## Incompatible Skills
+This skill has known intent collisions with the following skills:
+- [skill-reminder.mycroftAI](https://github.com/mycroftai/skill-reminder)
+- [skill-alarm.mycroftAI](https://github.com/mycroftai/skill-alarm)
+- [mycroft-timer.mycroftAI](https://github.com/mycroftai/mycroft-timer)
+```
+---
+`Credits` contains some users/organizations who contributed to the skill. This
+section is optional, but it is best practice to specify user/org names with links
+to their GitHub account. Names without account links are also supported
+```markdown
+## Credits
+[NeonGeckoCom](https://github.com/NeonGeckoCom)
+[NeonDaniel](https://github.com/NeonDaniel)
+```
+---
+`Category` contains some categories this skill fits under, with the "primary" category
+bolded (`**`Category`**`). Valid categories are:
+- Daily
+- Configuration
+- Entertainment
+- Information
+- IoT
+- Music & Audio
+- Media
+- Productivity
+- Transport
+```markdown
+## Category
+**Productivity**
+Daily
+```
+---
+`Tags` contain some tags that apply to the skill. There are no hard rules about
+what may be in a tag, but `NeonGecko Original` is reserved for use with skills
+owned by the `NeonGeckoCom` organization.
+
+## LICENSE.md
+Every project on GitHub should contain a `LICENSE.md` file with a known license.
+This file will be parsed to try and determine the license applied to the skill,
+otherwise it will be listed as 'unknown'
+
+## requirements.txt
+This is a standard Python requirements file with one package per line. Lines
+with a leading `#` are ignored as comments.
+
+## manifest.yml
+This is a specification [from MycroftAI](https://github.com/MycroftAI/documentation/blob/master/docs/skill-development/skill-structure/dependencies/manifest-yml.md)
+to specify requirements. A skill will generally contain either `requirements.txt`
+OR `manifest.yml`.

--- a/docs/skill_development/skill_testing.md
+++ b/docs/skill_development/skill_testing.md
@@ -1,0 +1,273 @@
+# Skill Testing
+Testing is an important aspect to skill development to ensure that a skill acts 
+as expected. Neon provides several automations to make basic testing trivial to
+implement and more advanced testing easier.
+
+## Automating Tests
+To enable automated tests with GitHub actions, create 
+`.github/workflows/skill_tests.yml` in your skill repository with the below snippet:
+
+```yaml
+# This workflow will run unit tests
+
+name: Test Skill
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  # TODO: Add any jobs here
+```
+
+The above automation means that build tests will be run any time a pull_request 
+is created/updated, or `Test Skill` is manually run from GitHub.
+
+## Build Tests
+For skills that include a `setup.py` file for installation, enabling build tests
+can help catch typos or errors. To enable this automation, add the below snippet
+to the GitHub automation [specified above](#automating-tests)
+
+```yaml
+  py_build_tests:
+    uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
+```
+
+## Install Tests
+For any skill (even those without `setup.py`), installation tests can be used to
+make sure the skill can be installed via [`osm`](https://github.com/OpenVoiceOS/ovos_skill_manager).
+To enable this automation, add the below snippet to the GitHub automation 
+[specified above](#automating-tests):
+
+```yaml
+  skill_install_tests:
+    uses: neongeckocom/.github/.github/workflows/skill_test_installation.yml@master
+```
+
+## Unit Tests
+Unit tests are generally a good way to make sure components are working as expected
+while building a skill. It is generally recommended to write unit tests while writing
+a skill.
+
+To enable this automation, specify `test/test_skill.py` and add the below 
+snippet to the GitHub automation [specified above](#automating-tests):
+
+```yaml
+  skill_unit_tests:
+    uses: neongeckocom/.github/.github/workflows/skill_tests.yml@master
+```
+
+### Example
+Using [skill-about](https://github.com/NeonGeckoCom/skill-about/blob/0.2.1/test/test_skill.py) as an example,
+unit tests are fairly simple to implement.
+
+The snippet below shows all of the common test code that can simply be copy/pasted
+to a new skill test:
+
+```python
+import json
+import os
+import shutil
+import unittest
+import pytest
+
+from os import mkdir
+from os.path import dirname, join, exists
+from mock import Mock
+from mycroft_bus_client import Message
+from ovos_utils.messagebus import FakeBus
+
+
+class TestSkill(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from mycroft.skills.skill_loader import SkillLoader
+
+        bus = FakeBus()
+        bus.run_in_thread()
+        skill_loader = SkillLoader(bus, dirname(dirname(__file__)))
+        skill_loader.load()
+        cls.skill = skill_loader.instance
+        cls.test_fs = join(dirname(__file__), "skill_fs")
+        if not exists(cls.test_fs):
+            mkdir(cls.test_fs)
+        cls.skill.settings_write_path = cls.test_fs
+        cls.skill.file_system.path = cls.test_fs
+
+        # Override speak and speak_dialog to test passed arguments
+        cls.skill.speak = Mock()
+        cls.skill.speak_dialog = Mock()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.test_fs)
+
+    def tearDown(self) -> None:
+        self.skill.speak.reset_mock()
+        self.skill.speak_dialog.reset_mock()
+
+    def test_00_skill_init(self):
+        # Test any parameters expected to be set in init or initialize methods
+        pass
+```
+
+The setup methods here create an instance of the skill class and mock the settings
+and file system parameters to prevent interfering with any installations on the
+system running tests. This also mocks `speak` and `speak_dialog` so test methods
+can check what is passed to those methods.
+
+Continuing with that example, a test for an intent handler would look like:
+```python
+def test_read_license(self):
+    valid_message = Message("test_message",
+                            {"tell": "tell", "license": "license"},
+                            {"neon_should_respond": True})
+    valid_message_long = Message("test_message",
+                                 {"tell": "tell", "license": "license",
+                                  "long": "long"},
+                                 {"neon_should_respond": True})
+
+    self.skill.read_license(valid_message)
+    self.skill.speak_dialog.assert_called_with("license_short")
+
+    self.skill.read_license(valid_message_long)
+    self.skill.speak_dialog.assert_called_with("license_long")
+```
+
+The `message` passed to the intent handler is mocked here with some expected
+`data` and `context`; note that the `msg_type` is unimportant in this case. The
+skill handler method `read_license` is called directly with the test `message`
+and calls to `speak_dialog` are tested to make sure the correct dialog was
+selected.
+
+The [unittest documentation](https://docs.python.org/3/library/unittest.html) is
+another helpful resource for testing other methods and there are various guides
+for writing generic unit tests, such as [this one from RealPython](https://realpython.com/python-testing/).
+
+## Resource Tests
+Resource tests ensure that any expected resource files are present and not empty.
+This is particularly useful for making sure supported languages are maintained
+and changes to the skill don't accidentally break language support.
+
+To enable this automation, specify `test/test_resources.yaml` and add the below 
+snippet to the GitHub automation [specified above](#automating-tests):
+
+```yaml
+  skill_resource_tests:
+    uses: neongeckocom/.github/.github/workflows/skill_test_resources.yml@master
+```
+
+### Example
+Using [skill-about](https://github.com/NeonGeckoCom/skill-about/blob/0.2.1/test/test_resources.yaml) 
+as an example, resource tests look like:
+
+```yaml
+# Specify resources to test here.
+
+# Specify languages to be tested
+languages:
+  - "en-us"
+  - "uk-ua"
+
+# vocab is lowercase .voc file basenames
+vocab:
+  - license
+  - long
+  - skills
+  - tell
+
+# dialog is .dialog file basenames (case-sensitive)
+dialog:
+  - license_long
+  - license_short
+  - skills_list
+# regex entities, not necessarily filenames
+regex: []
+intents:
+  # Padatious intents are the `.intent` file names
+  padatious: []
+  # Adapt intents are the name passed to the constructor
+  adapt:
+    - LicenseIntent
+    - ListSkillsIntent
+```
+
+Comments in the above file describe how to fill out each section; this file generally
+shouldn't change unless a new intent is added to a skill. Also note that both missing
+AND extraneous files will result in a test failure.
+
+## Intent Tests
+Intent tests make sure that a skill matches user utterances to intents as expected.
+Intent tests are very useful in making sure a skill handler handles all the user
+utterance it should and not the ones it shouldn't.
+
+It is also helpful to take reported intent failures or invalid matches and add
+them to the tests here and then adjust intent resources to achieve the desired
+behavior.
+
+To enable this automation, specify `test/test_intents.yaml` and add the below 
+snippet to the GitHub automation [specified above](#automating-tests):
+
+```yaml
+  skill_resource_tests:
+    uses: neongeckocom/.github/.github/workflows/skill_test_intents.yml@master
+```
+
+### Example
+Using [skill-about](https://github.com/NeonGeckoCom/skill-about/blob/0.2.1/test/test_intents.yaml) 
+as an example, resource tests look like:
+
+```yaml
+# Specify intents to test here. Valid test cases are as follows:
+
+# Basic intent match tests only:
+#lang:
+#  intent_name:
+#    - example utterance
+#    - other example utterance
+
+# Intent tests with expected vocab/entity matches:
+#lang:
+#  intent_name:
+#    - example_utterance:
+#        - expected vocab name
+#        - other expected vocab name
+
+# Intent tests with specific vocab/entity extraction tests:
+#lang:
+#  intent_name:
+#    - example_utterance:
+#        - expected_vocab_key: expected_vocab_value
+#        - expected_entity_key: expected_entity_value
+
+
+en-us:
+  LicenseIntent:
+  - what is your license
+  - what is my license
+  - tell me the license
+  - tell me the full license:
+      - long: full
+  - tell me my complete license:
+      - long: complete
+  ListSkillsIntent:
+    - tell me my skills
+    - tell me installed skills
+    - what skills are installed
+    - what can you do
+
+unmatched intents:
+  en-us:
+    - what is your name
+    - what is my name
+    - tell me what a skill is
+#    - tell me what skills are
+    - what can you tell me about life
+    - tell me what a license is
+```
+
+The comments in the above file note how to specify valid intent matches, including
+optional checks for extracted intent data (vocab/entity/regex).
+
+The `unmatched intents` specifies utterances that should match no intent in this
+skill and are useful for making sure a skill will work well with other skills.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,4 +34,5 @@ nav:
   - Developer References:
       - Working with Git(Hub): developers/git_overview.md
   - Skill Development:
+      - Adapt Intents: skill_development/adapt_intents.md
       - Padatious Intents: skill_development/padatious_intents.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,3 +33,5 @@ nav:
     - Installing Plugins: quick_reference/installing_plugins.md
   - Developer References:
       - Working with Git(Hub): developers/git_overview.md
+  - Skill Development:
+      - Padatious Intents: skill_development/padatious_intents.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - Installing Plugins: quick_reference/installing_plugins.md
   - Developer References:
       - Working with Git(Hub): developers/git_overview.md
+      - skill.json: developers/skill_json.md
   - Skill Development:
       - Adapt Intents: skill_development/adapt_intents.md
       - Padatious Intents: skill_development/padatious_intents.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,3 +36,4 @@ nav:
   - Skill Development:
       - Adapt Intents: skill_development/adapt_intents.md
       - Padatious Intents: skill_development/padatious_intents.md
+      - Testing: skill_development/skill_testing.md


### PR DESCRIPTION
# Description
Beginning implementation of skill documentation.
Includes Padatious and Adapt docs that are skill-oriented
Includes testing/automation docs to encourage skill tests

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This does not include documentation for skill design or packaging, but includes skill.json, testing, and intent parser docs