### PR TITLE
Fix incorrect formatting on Messagebus page

### DIFF
--- a/docs/neon_core/neon_messagebus.md
+++ b/docs/neon_core/neon_messagebus.md
@@ -5,6 +5,7 @@ connected modules.
 
 ## Neon Enhancements
 `neon-messagebus` extends `mycroft.messagebus` with the following added functionality:
+
 * Utilities for sending files and other data over the bus
 * A service for managing "signals" used for IPC
 


### PR DESCRIPTION
# Description

What the title says. The bullet points were previously being squished into the same paragraph instead of turned into \<li>s. See https://neongeckocom.github.io/neon-docs/neon_core/neon_messagebus/