### PR TITLE
Fix dead link to ovos docs in configuration reference

### DIFF
--- a/docs/quick_reference/configuration.md
+++ b/docs/quick_reference/configuration.md
@@ -2,8 +2,8 @@
 
 Neon Core configuration follows the same general structure as
 [Mycroft](https://mycroft-ai.gitbook.io/docs/using-mycroft-ai/customizations/mycroft-conf)
-and [OVOS](https://openvoiceos.github.io/community-docs/config/), with the main
-difference that Neon uses [YAML](https://yaml.org/) formatting.
+and [OVOS](https://openvoiceos.github.io/community-docs//unused/config_ovos_core/),
+with the main difference being that Neon uses [YAML](https://yaml.org/) formatting.
 
 ## Core Configuration Files
 


### PR DESCRIPTION
# Description
Updates link to OVOS Configuraiton Docs 

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
As noted in [Matrix chat](https://matrix.to/#/!ZhEZYNzKBfpEAhtQIz:matrix.org/$55hbT5_Ne66otfk0y2TOpsIOMT9_XLeQpXWMp7KyIPo?via=matrix.org&via=nitro.chat&via=rx.haunted.computer)