### PR TITLE
Document workflow for triaging GitHub issues

### DIFF
--- a/docs/operations/git/triage_issues.md
+++ b/docs/operations/git/triage_issues.md
@@ -10,7 +10,7 @@ This process applies in the following situations:
 ### Process
 - Open the new issue on GitHub.
 - Read the issue comment and verify it is valid and complete.
-  - If this is a duplicate issue, close it with a comment linking the existing issue.
+  - If this is a duplicate issue, apply the `duplicate` tag, close it with a comment linking the existing issue.
   - If the issue is mis-categorized as a bug or feature, update the PR title.
   - If the issue is in the wrong repository, transfer it as appropriate.
 - If you know about more context (i.e. a chat thread or forum post), add it to the issue description.

--- a/docs/operations/git/triage_issues.md
+++ b/docs/operations/git/triage_issues.md
@@ -1,0 +1,27 @@
+## Triage GitHub Issues
+This describes the process for triaging new issues on GitHub
+
+### Application
+This process applies in the following situations:
+- A new issue is created in a repository you maintain
+- A weekly review of the [GitHub Issues Report](https://github.com/NeonGeckoCom/.github/actions/workflows/get_issues.yml)
+> The process below applies to each issue
+
+### Process
+- Open the new issue on GitHub.
+- Read the issue comment and verify it is valid and complete.
+  - If this is a duplicate issue, close it with a comment linking the existing issue.
+  - If the issue is mis-categorized as a bug or feature, update the PR title.
+  - If the issue is in the wrong repository, transfer it as appropriate.
+- If you know about more context (i.e. a chat thread or forum post), add it to the issue description.
+- If more information is needed for debugging, reply to the issue asking the author to clarify.
+- Verify the correct labels are applied (`bug`, `enhancement`, `documentation`, etc.)
+- Assign the issue to the "Community Projects" board if applicable.
+  > Issues in public repositories generally belong here in the "Other Helpful Tasks" section.
+- If you are going to address the issue, assign yourself to the issue.
+- If the issue can be addressed by a community member with minimal knowledge of other
+  interacting repositories, add the `help wanted` label.
+- If the `triage` label is applied to the issue, remove it
+
+### Exceptions
+- There should be no exceptions to this process.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
             - Alpha Release Review Workflow: operations/libraries/workflow_review_alpha.md
         - Git:
             - Undo a Stable PR Workflow: operations/git/undo_stable_pr.md
+            - Triage New GitHub Issues: operations/git/triage_issues.md
         - Skills:
             - Stable Release Workflow: operations/skills/workflow_stable_release.md
             - Alpha Release Workflow: operations/skills/workflow_alpha_release.md


### PR DESCRIPTION
# Description
Add GitHub Issue triage workflow

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Relates to https://github.com/NeonGeckoCom/.github/pull/73
- ~Consider updating issue templates to add a `triage` label before this~ Done